### PR TITLE
remove unused modules references on exit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,12 @@
 export default function (babel) {
   return {
     visitor: {
-      Program(path, state) {
-        path.traverse(removeTargetModuleReferences, state);
-        path.scope.crawl();
-        path.traverse(removeUnusedModulesReferences, state);
+      Program: {
+        exit(path, state) {
+          path.traverse(removeTargetModuleReferences, state);
+          path.scope.crawl();
+          path.traverse(removeUnusedModulesReferences, state);
+        }
       }
     }
   };


### PR DESCRIPTION
Let other babel plugins remove stuff and still remove unused imports after that.
